### PR TITLE
fix redirect and keep tab open

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,19 +1,19 @@
 // Paths listed below shouldn't be redirect to application.
 const exceptingPaths = [
   '/desktop', '/login', '/mobile', '/product', '/pricing', '/native',
-]
+];
 
 function redirect(details) {
   // Ignore urls which are not for document pages, such as js/css file and more.
   if (details.documentUrl) {
     return {};
   }
-  
+
   const element = document.createElement('a');
   element.href = details.url;
 
   // Ignore some reserved keywords for notion homepage.
-  if (!element.pathname 
+  if (!element.pathname
       || element.pathname === '/'
       || exceptingPaths.find(path => element.pathname.startsWith(path))
   ) {
@@ -21,15 +21,8 @@ function redirect(details) {
   }
 
   // Redirect with scheme.
-  const notionScheme = 'notion:/' + element.pathname;
-  try {
-    return { redirectUrl: notionScheme };
-  } finally {
-    // Close tab after 2 seconds.
-    if (details.tabId !== -1) {
-      setTimeout(() => browser.tabs.remove(details.tabId), 2000);
-    }
-  }
+  const notionScheme = details.url.replace('https', 'notion');
+  return { redirectUrl: notionScheme };
 }
 
 const filters = { urls: ['*://*.notion.so/*'] };


### PR DESCRIPTION
**Problem**
Notion links to projects which you are not a member fail to open.
example: https://www.notion.so/Open-a-Notion-URL-in-the-desktop-app-8a663e8507ff47369f2cb9246ca23788

the extension attempts to redirect to notion://Open-a-Notion-URL-in-the-desktop-app-8a663e8507ff47369f2cb9246ca23788

this will fail if the page is not in your local project. 
What will happen is:
1. notion app will open to the default home page
2. firefox tab will close

**Solution**
This fix does do things:
1. replaces redirect with the full path e.g. (notion://www.notion.so/Open-a-Notion-URL-in-the-desktop-app-8a663e8507ff47369f2cb9246ca23788) which will render the notion page in your local app.
2. does not close the tab so if there is a problem you can still read it in the browser.

Other ways to fix this might be expanding the list of ignored paths. but I think there will always be corner cases.

**Testing**
Ran the extension in local debug mode.
