### PR TITLE
Exclude /invoice from paths

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,6 +1,6 @@
 // Paths listed below shouldn't be redirect to application.
 const exceptingPaths = [
-  '/desktop', '/login', '/mobile', '/product', '/pricing', '/native',
+  '/desktop', '/login', '/mobile', '/product', '/pricing', '/native', '/invoice',
 ];
 
 function redirect(details) {


### PR DESCRIPTION
When trying to open an invoice in Notion, it opens the browser, which then gets locked in redirect loop.