### PR TITLE
Add "help" to exclusion list to avoid infinite loop

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,6 +1,6 @@
 // Paths listed below shouldn't be redirect to application.
 const exceptingPaths = [
-  '/desktop', '/login', '/mobile', '/product', '/pricing', '/native', '/invoice', '/web-clipper',
+  '/desktop', '/login', '/mobile', '/product', '/pricing', '/native', '/invoice', '/web-clipper', '/help'
 ];
 
 async function redirect(details) {


### PR DESCRIPTION
Opening Notion's help pages creates an infinite loop.

Reproduce by clicking this: https://www.notion.so/help/guides/create-and-use-an-upvote-formula-for-team-decisions